### PR TITLE
Get custom user model

### DIFF
--- a/templated_emails/utils.py
+++ b/templated_emails/utils.py
@@ -8,7 +8,10 @@ from django.template.loader import render_to_string
 from django.utils.translation import get_language, activate
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
 
 try:
     from celery.task import task


### PR DESCRIPTION
Fixed the error "AttributeError: Manager isn't available; User has been swapped for 'users.User'"
