### PR TITLE
call get_user_model() at run time

### DIFF
--- a/templated_emails/utils.py
+++ b/templated_emails/utils.py
@@ -10,8 +10,6 @@ from django.db import models
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth import get_user_model
 
-User = get_user_model()
-
 
 try:
     from celery.task import task
@@ -43,8 +41,8 @@ def send_templated_email(recipients, template_path, context=None,
         if it is users the system will change to the language that the
         user has set as theyr mother toungue
     """
-    recipient_pks = [r.pk for r in recipients if isinstance(r, User)]
-    recipient_emails = [e for e in recipients if not isinstance(e, User)]
+    recipient_pks = [r.pk for r in recipients if isinstance(r, get_user_model())]
+    recipient_emails = [e for e in recipients if not isinstance(e, get_user_model())]
     send = _send_task.delay if use_celery else _send
     msg = send(recipient_pks, recipient_emails, template_path, context, from_email,
          fail_silently, extra_headers=extra_headers)
@@ -54,7 +52,7 @@ def send_templated_email(recipients, template_path, context=None,
 
 def _send(recipient_pks, recipient_emails, template_path, context, from_email,
           fail_silently, extra_headers=None):
-    recipients = list(User.objects.filter(pk__in=recipient_pks))
+    recipients = list(get_user_model().objects.filter(pk__in=recipient_pks))
     recipients += recipient_emails
 
     current_language = get_language()
@@ -70,7 +68,7 @@ def _send(recipient_pks, recipient_emails, template_path, context, from_email,
 
     for recipient in recipients:
         # if it is user, get the email and switch the language
-        if isinstance(recipient, User):
+        if isinstance(recipient, get_user_model()):
             email = recipient.email
             try:
                 language = get_users_language(recipient)
@@ -109,7 +107,7 @@ def _send(recipient_pks, recipient_emails, template_path, context, from_email,
         msg.send(fail_silently=fail_silently)
 
         # reset environment to original language
-        if isinstance(recipient, User):
+        if isinstance(recipient, get_user_model()):
             activate(current_language)
 
         return msg


### PR DESCRIPTION
setting User = get_user_model() at import time means that you can't call templated-emails from the same models.py that defines your custom user model, since your user model won't be compiled yet in its own models.py.  So if your custom User model does something that sends an email, you're going to get a circular dependency problem as long as templated-emails calls get_user_model() at import time.

We have a User model that wants to send an email confirmation when is_active gets set to True (when the user confirms their email address).  This patch allows us to call templated-emails from our custom User model.

Without this patch, we need to perform the import at run-time every time we want to send an email, which is ugly and slow.

Vielen Dank!
